### PR TITLE
Add support for Temporary Credentials Access

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ Add the following in `app/filesystems.php`:
             'driver' => 'obs',
             'access_id' => env('OBS_ACCESS_KEY_ID'),
             'access_key' => env('OBS_ACCESS_KEY_SECRET'),
+            'security_token' => env('OBS_ACCESS_SESSION_KEY'), // required for temporary access credentials
             'bucket' => env('OBS_BUCKET'),
             'endpoint' => env('OBS_ENDPOINT'), // OBS 外网节点或自定义外部域名
             'endpoint_internal' => env('OBS_ENDPOINT_INTERNAL'), // 如果为空，则默认使用 endpoint 配置

--- a/src/Providers/HuaweiObsServiceProvider.php
+++ b/src/Providers/HuaweiObsServiceProvider.php
@@ -30,6 +30,7 @@ class HuaweiObsServiceProvider extends ServiceProvider
             $client = new ObsClient([
                 'key' => $config['access_id'],
                 'secret' => $config['access_key'],
+                'security_token' => $config['security_token'] ?? null,
                 'proxy' => $config['proxy'] ?? null,
                 'endpoint' => $epInternal,
                 'ssl_verify' => $ssl,


### PR DESCRIPTION
For Temporary Credentials Access, Huawei OBS requires the **security_token**, it was missing from this filesystem provider so i added it.
This security_token has official support in OBS Client by huawei.